### PR TITLE
build: Fix issue with IDEs not working properly when linking .projects

### DIFF
--- a/src/platform/windows/CMakeLists.txt
+++ b/src/platform/windows/CMakeLists.txt
@@ -16,6 +16,8 @@ else()
   message(FATAL_ERROR "MSVC is the only compiler currently supported on Windows!")
 endif()
 
+target_precompile_headers(browsercontrol PRIVATE pch.hpp)
+
 include(nugetfetch)
 
 nugetfetch(WebView2 "Microsoft.Web.WebView2" "1.0.1418.22")
@@ -33,15 +35,17 @@ endif()
 # Let MSBuild know we want to statically link WebView2
 set_target_properties(browsercontrol PROPERTIES VS_GLOBAL_WebView2LoaderPreference Static)
 
-target_link_libraries(browsercontrol PRIVATE ${WebView2-PATH}/build/native/Microsoft.Web.WebView2.targets)
-target_link_libraries(
-  browsercontrol
-  PRIVATE ${WindowsImplementationLibrary-PATH}/build/native/Microsoft.Windows.ImplementationLibrary.targets
+# urlmon.lib is required for URLDownloadToFile
+target_link_libraries(browsercontrol PRIVATE urlmon.lib ${WebView2-PATH}/build/native/Microsoft.Web.WebView2.targets)
+
+# UGLY: From CMAKE 3.8 passing a `.targets` file to `target_link_libraries` should properly import the referenced
+# targets into the resulting project files. This works for the build, but unfortunately every IDE I've tried does not
+# properly handle this for intellisense.
+#
+# Because of this we are both utilizing `target_link_libraries` with the `.targets` file, and
+# `target_include_directories` for the WebView2 target
+target_include_directories(
+  browsercontrol PRIVATE ${WebView2-PATH}/build/native/include ${WindowsImplementationLibrary-PATH}/include
 )
 
 target_sources(browsercontrol PRIVATE init.cpp BrowserData.cpp Win32BrowserControl.cpp WebView2BrowserWindow.cpp)
-
-target_precompile_headers(browsercontrol PRIVATE pch.hpp)
-
-# Required for URLDownloadToFile
-target_link_libraries(browsercontrol PRIVATE urlmon.lib)


### PR DESCRIPTION
`.projects` files make cross-arch linking much easier, but messed up IDE intellisense. Unfortunately this hack is necessary to make the IDEs I work with function properly.

Signed-off-by: Open592 Developer <uss@open592.com>