### PR TITLE
windows: Install WebView2 silently

### DIFF
--- a/examples/ExampleAppletViewer/AdvertFrame.java
+++ b/examples/ExampleAppletViewer/AdvertFrame.java
@@ -45,7 +45,7 @@ public final class AdvertFrame {
         innerContainer.setLayout(null);
 
         fakeApplet = new Panel();
-        fakeApplet.setBackground(Color.green);
+        fakeApplet.setBackground(Color.red);
         fakeApplet.setLayout(null);
 
         frame.add(innerContainer, "Center");
@@ -74,6 +74,7 @@ public final class AdvertFrame {
             return;
         }
 
+        fakeApplet.setBackground(Color.green);
         frame.addWindowListener(TerminateHandler.initialize());
         innerContainer.addComponentListener(AdvertComponentListener.initialize());
     }

--- a/src/platform/windows/WebView2BrowserWindow.cpp
+++ b/src/platform/windows/WebView2BrowserWindow.cpp
@@ -73,8 +73,8 @@ bool WebView2BrowserWindow::InstallWebView() noexcept
     si.cb = sizeof(si);
     ZeroMemory(&pi, sizeof(pi));
 
-    bool success
-        = CreateProcess(installerPath.c_str(), nullptr, nullptr, nullptr, false, 0, nullptr, nullptr, &si, &pi);
+    std::wstring command = std::format(L"{} /silent /install", installerPath);
+    bool success = CreateProcess(nullptr, command.data(), nullptr, nullptr, false, 0, nullptr, nullptr, &si, &pi);
 
     if (!success) {
         return false;

--- a/src/platform/windows/pch.hpp
+++ b/src/platform/windows/pch.hpp
@@ -6,8 +6,8 @@
 #define WIN32_LEAN_AND_MEAN
 #define UNICODE
 #include <Windows.h>
-#include <urlmon.h> // For URLDownloadToFile
 #include <processthreadsapi.h> // For CreateProcess
+#include <urlmon.h> // For URLDownloadToFile
 
 #include <ShlObj.h>
 #include <wil/com.h>
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <filesystem>
+#include <format>
 #include <memory>
 #include <optional>
 #include <string>


### PR DESCRIPTION
When installing webview2 use the recommended flags `/silent /install` which results in installing WebView2 silently. This results in a better use experience since the user shouldn't need to be aware that we are installing WebView2. It also resembles the original more closely since there was never a installer dialog.