### PR TITLE
linux: Add logic to locate/fetch CEF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,9 @@ trim_trailing_whitespace = true
 [*.{cpp,hpp, c, h}]
 indent_size = 4
 indent_style = space
+
+# TODO: This could get out of sync with cmake-format
+[{CMakeLists.txt,*.cmake}]
+indent_size = 2
+indent_style = space
+

--- a/cmake/Modules/FindCEF.cmake
+++ b/cmake/Modules/FindCEF.cmake
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+include(FetchContent)
+include(FindPackageHandleStandardArgs)
+
+# FindCEF
+#
+# This is a cmake module which will ensure CEF (Chromium Embedded Framework) is installed on the machine.
+#
+# You can read more about CEF here: https://bitbucket.org/chromiumembedded/cef/src/master/
+#
+# Thank you to the OBS Project for their implementation of FindCEF which I used as a reference:
+# https://github.com/obsproject/obs-browser/blob/master/FindCEF.cmake
+#
+# Logic of FindCEF
+#
+# If `LOCAL_CEF_ROOT_DIR` is defined attempt to find the CEF distribution at that location
+#
+# If `LOCAL_CEF_ROOT_DIR` is *NOT* set, *OR* it doesn't point to a valid CEF distribution we will attempt to download a
+# valid distribution for the machine arch.
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  message(FATAL_ERROR "Attempted to utilize FindCEF on a non-Linux machine!")
+endif()
+
+# We will only be including CEF for our Linux builds
+#
+# * x86_64
+# * ARM
+# * ARM64
+set(CEF_VERSION "cef_binary_107.1.12+g65b79a6+chromium-107.0.5304.122")
+
+# Validate that we are running a supported architecture
+if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  set(CEF_MACHINE_ARCH "linux64")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  set(CEF_MACHINE_ARCH "linuxarm64")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
+  set(CEF_MACHINE_ARCH "linuxarm")
+else()
+  message(FATAL_ERROR "CEF is required, but not supported on your architecture")
+endif()
+
+# Attempt to find CEF on the local FS
+if(LOCAL_CEF_ROOT_DIR)
+  message(STATUS "Attempting to find CEF distribution within ${LOCAL_CEF_ROOT_DIR}")
+  message(STATUS "NOTE: We are expecting a version compatible with ${CEF_VERSION}!")
+
+  find_path(CEF_INCLUDE_DIR "include/cef_version.h" HINTS "${LOCAL_CEF_ROOT_DIR}")
+
+  find_library(
+    CEF_LIBRARY
+    NAMES libcef.so "Chromium Embedded Framework"
+    NO_DEFAULT_PATH
+    PATHS "${LOCAL_CEF_ROOT_DIR}" "${LOCAL_CEF_ROOT_DIR}/Release"
+  )
+
+  find_library(
+    CEFWRAPPER_LIBRARY
+    NAMES libcef_dll_wrapper.a
+    NO_DEFAULT_PATH
+    PATHS "${LOCAL_CEF_ROOT_DIR}" "${LOCAL_CEF_ROOT_DIR}/Release" "${LOCAL_CEF_ROOT_DIR}/Release/libcef_dll_wrapper"
+          "${LOCAL_CEF_ROOT_DIR}/build/libcef_dll_wrapper"
+  )
+
+  if(CEF_INCLUDE_DIR
+     AND CEF_LIBRARY
+     AND CEFWRAPPER_LIBRARY
+  )
+    set(LOCATED_LOCAL_CEF TRUE)
+  elseif()
+    set(LOCATED_LOCAL_CEF FALSE)
+
+    unset(CEF_INCLUDE_DIR)
+    unset(CEF_LIBRARY)
+    unset(CEFWRAPPER_LIBRARY)
+
+    message(WARNING "Failed to find valid CEF distribution within ${LOCAL_CEF_ROOT_DIR}")
+  endif()
+endif()
+
+# If we haven't found a distribution locally we need to fetch from the CDN
+if(NOT LOCATED_LOCAL_CEF)
+  set(CEF_NAME "${CEF_VERSION}_${CEF_MACHINE_ARCH}")
+  set(CEF_URL "https://github.com/Open592/cef-release/releases/download/${CEF_VERSION}/${CEF_NAME}.tar.bz2")
+
+  message(STATUS "=====!!!NOTE:!!!=====")
+  message(STATUS "Downloading CEF from: ${CEF_URL}")
+  message(STATUS "This will significantly increase configure time!")
+  message(STATUS "You may use `LOCAL_CEF_ROOT_DIR` to specify a local path for CEF to avoid this.")
+  message(STATUS "=====!!!NOTE!!!=====")
+
+  set(FETCHCONTENT_BASE_DIR "${CMAKE_BINARY_DIR}/packages/external/cef")
+  set(FETCHCONTENT_QUIET OFF)
+
+  FetchContent_Declare(cef URL ${CEF_URL})
+  FetchContent_MakeAvailable(cef)
+
+  find_path(CEF_INCLUDE_DIR "include/cef_version.h" HINTS "${cef_SOURCE_DIR}")
+
+  find_library(
+    CEF_LIBRARY
+    NAMES libcef.so "Chromium Embedded Framework"
+    NO_DEFAULT_PATH
+    PATHS "${cef_SOURCE_DIR}"
+  )
+
+  find_library(
+    CEFWRAPPER_LIBRARY
+    NAMES libcef_dll_wrapper.a
+    NO_DEFAULT_PATH
+    PATHS "${cef_SOURCE_DIR}"
+  )
+endif()
+
+if(NOT CEF_INCLUDE_DIR)
+  message(WARNING "Failed to find CEF_INCLUDE_DIR")
+  set(CEF_FOUND FALSE)
+  return()
+elseif(NOT CEF_LIBRARY)
+  message(WARNING "Failed to find CEF_LIBRARY")
+  set(CEF_FOUND FALSE)
+  return()
+elseif(NOT CEFWRAPPER_LIBRARY)
+  message(WARNING "Failed to find CEFWRAPPER_LIBRARY")
+  set(CEF_FOUND FALSE)
+  return()
+elseif()
+  message(STATUS "Found CEF: ${CEF_LIBRARY};${CEFWRAPPER_LIBRARY}")
+endif()
+
+find_package_handle_standard_args(CEF DEFAULT_MSG CEF_INCLUDE_DIR CEF_LIBRARY CEFWRAPPER_LIBRARY)
+
+mark_as_advanced(CEF_INCLUDE_DIR CEF_LIBRARY CEFWRAPPER_LIBRARY)

--- a/cmake/Modules/NugetFetch.cmake
+++ b/cmake/Modules/NugetFetch.cmake
@@ -9,7 +9,7 @@
 # PACKAGE_NAME :: NuGet package name we want to fetch
 #
 # VERSION :: Version of the package we want to fetch
-function(nugetfetch OUTPUT_NAME PACKAGE_NAME PACKAGE_VERSION)
+function(NugetFetch OUTPUT_NAME PACKAGE_NAME PACKAGE_VERSION)
   find_program(NUGET_EXE nuget)
 
   if(NOT NUGET_EXE)

--- a/src/platform/linux/CMakeLists.txt
+++ b/src/platform/linux/CMakeLists.txt
@@ -26,4 +26,6 @@ find_package(X11 REQUIRED)
 target_link_libraries(browsercontrol PRIVATE ${X11_LIBRARIES})
 target_include_directories(browsercontrol PRIVATE ${X11_INCLUDE_DIR})
 
+include(FindCEF)
+
 target_sources(browsercontrol PRIVATE CEFBrowserControl.cpp init.cpp)

--- a/src/platform/linux/CMakeLists.txt
+++ b/src/platform/linux/CMakeLists.txt
@@ -22,10 +22,9 @@ target_compile_options(browsercontrol PRIVATE
 target_precompile_headers(browsercontrol PRIVATE pch.hpp)
 
 find_package(X11 REQUIRED)
+find_package(CEF REQUIRED)
 
-target_link_libraries(browsercontrol PRIVATE ${X11_LIBRARIES})
-target_include_directories(browsercontrol PRIVATE ${X11_INCLUDE_DIR})
-
-include(FindCEF)
+target_link_libraries(browsercontrol PRIVATE ${X11_LIBRARIES} ${CEF_LIBRARY} ${CEFWRAPPER_LIBRARY})
+target_include_directories(browsercontrol PRIVATE ${X11_INCLUDE_DIR} ${CEF_INCLUDE_DIR})
 
 target_sources(browsercontrol PRIVATE CEFBrowserControl.cpp init.cpp)

--- a/src/platform/windows/CMakeLists.txt
+++ b/src/platform/windows/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 target_precompile_headers(browsercontrol PRIVATE pch.hpp)
 
-include(nugetfetch)
+include(NugetFetch)
 
 nugetfetch(WebView2 "Microsoft.Web.WebView2" "1.0.1418.22")
 


### PR DESCRIPTION
Ensure CEF is present on the build machine.

We allow for setting `LOCAL_CEF_ROOT_DIR` to specify a local copy of CEF.

If this is not present or doesn't point to a valid distribution, we fetch from Open592/cef-release

Signed-off-by: Open592 Developer <uss@open592.com>