### PR TITLE
Refactor Linux shutdown routine

### DIFF
--- a/src/BrowserData.cpp
+++ b/src/BrowserData.cpp
@@ -68,16 +68,19 @@ void BrowserData::SetState(State state) noexcept
     m_cv.notify_one();
 }
 
+void BrowserData::WaitForStateTransition(State state) noexcept
+{
+    std::unique_lock lk(m_mutex);
+
+    m_cv.wait(lk, [this, state] { return m_state != state; });
+}
+
 /**
  * Report the initialization result after the browser status has transitioned to something other than NOT_STARTED
  */
 bool BrowserData::WaitForInitializationResult() noexcept
 {
-    {
-        std::unique_lock lk(m_mutex);
-
-        m_cv.wait(lk, [this] { return m_state != State::NOT_STARTED; });
-    }
+    WaitForStateTransition(State::NOT_STARTED);
 
     return IsRunning();
 }

--- a/src/BrowserData.hpp
+++ b/src/BrowserData.hpp
@@ -60,6 +60,7 @@ public:
     void SetDestination(const std::wstring&) noexcept;
     void SetSize(int, int) noexcept;
     void SetState(State) noexcept;
+    void WaitForStateTransition(State) noexcept;
     [[nodiscard]] bool WaitForInitializationResult() noexcept;
 
 private:

--- a/src/platform/linux/BrowserControlApp.cpp
+++ b/src/platform/linux/BrowserControlApp.cpp
@@ -11,6 +11,17 @@ BrowserControlApp::BrowserControlApp(std::shared_ptr<BrowserData> data, CefWindo
 {
 }
 
+BrowserControlApp::~BrowserControlApp() { m_client = nullptr; }
+
+void BrowserControlApp::ShutDown()
+{
+    auto browser = m_client->GetBrowser();
+
+    if (browser) {
+        browser->GetHost()->CloseBrowser(true);
+    }
+}
+
 void BrowserControlApp::OnBeforeCommandLineProcessing(
     const CefString& processType, CefRefPtr<CefCommandLine> commandLine)
 {
@@ -23,7 +34,7 @@ void BrowserControlApp::OnContextInitialized()
 
     CefBrowserSettings browserSettings;
 
-    CefRefPtr<BrowserControlClient> client = BrowserControlClient::The();
+    m_client = new BrowserControlClient(m_data);
 
     CefWindowInfo windowInfo;
 
@@ -31,13 +42,11 @@ void BrowserControlApp::OnContextInitialized()
     windowInfo.SetAsChild(m_handle, CefRect(0, 0, m_data->GetWidth(), m_data->GetHeight()));
 
     bool result = CefBrowserHost::CreateBrowser(
-        windowInfo, client, m_data->GetDestination(), browserSettings, nullptr, nullptr);
+        windowInfo, m_client, m_data->GetDestination(), browserSettings, nullptr, nullptr);
 
     if (!result) {
         m_data->SetState(BrowserData::State::FAILED_TO_START);
 
         return;
     }
-
-    m_data->SetState(BrowserData::State::RUNNING);
 }

--- a/src/platform/linux/BrowserControlApp.hpp
+++ b/src/platform/linux/BrowserControlApp.hpp
@@ -4,11 +4,16 @@
 
 #include <include/cef_app.h>
 
-#include "../../BrowserData.hpp"
+#include "src/BrowserData.hpp"
+
+#include "BrowserControlClient.hpp"
 
 class BrowserControlApp : public CefApp, public CefBrowserProcessHandler {
 public:
     explicit BrowserControlApp(std::shared_ptr<BrowserData>, CefWindowHandle) noexcept;
+    ~BrowserControlApp() override;
+
+    void ShutDown();
 
     // CefApp overrides
     CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override { return this; }
@@ -18,6 +23,7 @@ public:
     void OnContextInitialized() override;
 
 private:
+    CefRefPtr<BrowserControlClient> m_client;
     std::shared_ptr<BrowserData> m_data;
     CefWindowHandle m_handle;
 

--- a/src/platform/linux/BrowserControlClient.cpp
+++ b/src/platform/linux/BrowserControlClient.cpp
@@ -4,11 +4,24 @@
 
 #include "BrowserControlClient.hpp"
 
-BrowserControlClient* BrowserControlClient::The()
+BrowserControlClient::BrowserControlClient(std::shared_ptr<BrowserData> data)
+    : m_data(std::move(data))
 {
-    static BrowserControlClient instance;
+}
 
-    return &instance;
+CefRefPtr<CefBrowser> BrowserControlClient::GetBrowser()
+{
+    if (m_browser) {
+        return m_browser;
+    }
+
+    return nullptr;
+}
+
+bool BrowserControlClient::DoClose(CefRefPtr<CefBrowser> browser)
+{
+    // Allow close to continue
+    return false;
 }
 
 void BrowserControlClient::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
@@ -36,4 +49,15 @@ void BrowserControlClient::OnAfterCreated(CefRefPtr<CefBrowser> browser)
     if (!m_browser) {
         m_browser = browser;
     }
+
+    m_data->SetState(BrowserData::State::RUNNING);
+}
+
+void BrowserControlClient::OnBeforeClose(CefRefPtr<CefBrowser>)
+{
+    if (m_browser) {
+        m_browser = nullptr;
+    }
+
+    m_data->SetState(BrowserData::State::TERMINATED);
 }

--- a/src/platform/linux/BrowserControlClient.hpp
+++ b/src/platform/linux/BrowserControlClient.hpp
@@ -4,12 +4,13 @@
 
 #include <include/cef_client.h>
 
+#include "src/BrowserData.hpp"
+
 class BrowserControlClient : public CefClient, public CefContextMenuHandler, public CefLifeSpanHandler {
 public:
-    static BrowserControlClient* The();
+    explicit BrowserControlClient(std::shared_ptr<BrowserData>);
 
-    BrowserControlClient(const BrowserControlClient&) = delete;
-    void operator=(const BrowserControlClient&) = delete;
+    CefRefPtr<CefBrowser> GetBrowser();
 
     // CefContextMenuHandler overrides
     CefRefPtr<CefContextMenuHandler> GetContextMenuHandler() override { return this; }
@@ -18,14 +19,16 @@ public:
     bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>, const CefString&, const CefString&,
         WindowOpenDisposition, bool, const CefPopupFeatures&, CefWindowInfo&, CefRefPtr<CefClient>&,
         CefBrowserSettings&, CefRefPtr<CefDictionaryValue>&, bool*) override;
+
     // CefLifeSpanHandler overrides
+    bool DoClose(CefRefPtr<CefBrowser> browser) override;
     CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }
     void OnAfterCreated(CefRefPtr<CefBrowser>) override;
+    void OnBeforeClose(CefRefPtr<CefBrowser>) override;
 
 private:
-    BrowserControlClient() = default;
-
     CefRefPtr<CefBrowser> m_browser;
+    std::shared_ptr<BrowserData> m_data;
 
     IMPLEMENT_REFCOUNTING(BrowserControlClient);
 };

--- a/src/platform/linux/LinuxBrowserControl.cpp
+++ b/src/platform/linux/LinuxBrowserControl.cpp
@@ -75,7 +75,12 @@ void LinuxBrowserControl::Destroy() noexcept
 {
     DCHECK(m_threadChecker.CalledOnValidThread());
 
-    // FIXME: Overhaul shutdown logic - close browsers and clients
+    m_app->ShutDown();
+
+    m_data->WaitForStateTransition(BrowserData::State::RUNNING);
+
+    m_app = nullptr;
+
     CefShutdown();
 }
 


### PR DESCRIPTION
There is still some work to be done but we are no longer reporting fatal
errors during shutdown.

An added benefit of passing BrowserData to the client is that we can now correctly report when the browser has started.