### PR TITLE
all: Stop storing BrowserData in Base::BrowserContext

### DIFF
--- a/src/BrowserContext.cpp
+++ b/src/BrowserContext.cpp
@@ -4,13 +4,6 @@
 
 namespace Base {
 
-BrowserContext::BrowserContext(std::unique_ptr<BrowserData> data) noexcept
-    : m_data(std::move(data))
-{
-}
-
-BrowserData* BrowserContext::GetBrowserData() const noexcept { return m_data.get(); }
-
 bool BrowserContext::Initialize(JNIEnv* env, jobject parentContainer, std::wstring initialDestination)
 {
     // We should not be initializing more than once.

--- a/src/BrowserContext.hpp
+++ b/src/BrowserContext.hpp
@@ -18,7 +18,7 @@ class BrowserContext {
 public:
     virtual ~BrowserContext() = default;
 
-    [[nodiscard]] virtual BrowserData* GetBrowserData() const noexcept;
+    [[nodiscard]] virtual BrowserData* GetBrowserData() const noexcept = 0;
 
     /**
      * @brief Initialize the browser window by passing both the parent container and initial destination.
@@ -41,9 +41,7 @@ public:
     void Navigate(std::wstring);
 
 protected:
-    explicit BrowserContext(std::unique_ptr<BrowserData>) noexcept;
-
-    std::unique_ptr<BrowserData> m_data;
+    BrowserContext() noexcept = default;
 
 private:
     // Each platform is responsible for implementing the API

--- a/src/platform/linux/LinuxBrowserContext.cpp
+++ b/src/platform/linux/LinuxBrowserContext.cpp
@@ -15,19 +15,13 @@ LinuxBrowserContext* LinuxBrowserContext::The()
 }
 
 LinuxBrowserContext::LinuxBrowserContext(std::unique_ptr<LinuxBrowserData> data) noexcept
-    : Base::BrowserContext(std::move(data))
+    : m_data(std::move(data))
 {
 }
 
 LinuxBrowserContext::~LinuxBrowserContext() noexcept = default;
 
-LinuxBrowserData* LinuxBrowserContext::GetBrowserData() const noexcept
-{
-    // This method would only ever be available when working on Windows
-    //
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-    return static_cast<LinuxBrowserData*>(Base::BrowserContext::GetBrowserData());
-}
+LinuxBrowserData* LinuxBrowserContext::GetBrowserData() const noexcept { return m_data.get(); }
 
 bool LinuxBrowserContext::PerformInitialize(JNIEnv* env, jobject canvas)
 {

--- a/src/platform/linux/LinuxBrowserContext.hpp
+++ b/src/platform/linux/LinuxBrowserContext.hpp
@@ -30,4 +30,6 @@ private:
     void PerformDestroy() override;
     void PerformResize() override;
     void PerformNavigate() override;
+
+    std::unique_ptr<LinuxBrowserData> m_data;
 };

--- a/src/platform/windows/WindowsBrowserContext.cpp
+++ b/src/platform/windows/WindowsBrowserContext.cpp
@@ -19,7 +19,7 @@ WindowsBrowserContext* WindowsBrowserContext::The() noexcept
 }
 
 WindowsBrowserContext::WindowsBrowserContext(std::unique_ptr<WindowsBrowserData> data)
-    : Base::BrowserContext(std::move(data))
+    : m_data(std::move(data))
 {
 }
 
@@ -30,13 +30,7 @@ WindowsBrowserContext::~WindowsBrowserContext() noexcept
     }
 }
 
-WindowsBrowserData* WindowsBrowserContext::GetBrowserData() const noexcept
-{
-    // This method would only ever be available when working on Windows
-    //
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-    return static_cast<WindowsBrowserData*>(Base::BrowserContext::GetBrowserData());
-}
+WindowsBrowserData* WindowsBrowserContext::GetBrowserData() const noexcept { return m_data.get(); }
 
 bool WindowsBrowserContext::PerformInitialize(JNIEnv* env, jobject canvas)
 {

--- a/src/platform/windows/WindowsBrowserContext.hpp
+++ b/src/platform/windows/WindowsBrowserContext.hpp
@@ -33,5 +33,6 @@ private:
 
     HWND m_browserWindow = nullptr;
 
+    std::unique_ptr<WindowsBrowserData> m_data;
     std::thread m_browserThread;
 };


### PR DESCRIPTION
Defer to the implementor to expose their own BrowserData.

This avoids the need to perform a static_cast in order to access the browser data from the derived classes.