### PR TITLE
all: Return BrowserData by reference.

### DIFF
--- a/src/BrowserContext.cpp
+++ b/src/BrowserContext.cpp
@@ -7,12 +7,12 @@ namespace Base {
 bool BrowserContext::Initialize(JNIEnv* env, jobject parentContainer, std::wstring initialDestination)
 {
     // We should not be initializing more than once.
-    if (!GetBrowserData() || GetBrowserData()->IsRunning()) {
+    if (GetBrowserData().IsRunning()) {
         return false;
     }
 
     if (!initialDestination.empty()) {
-        GetBrowserData()->SetDestination(std::move(initialDestination));
+        GetBrowserData().SetDestination(std::move(initialDestination));
     }
 
     return PerformInitialize(env, parentContainer);
@@ -20,7 +20,7 @@ bool BrowserContext::Initialize(JNIEnv* env, jobject parentContainer, std::wstri
 
 void BrowserContext::Destroy()
 {
-    if (!GetBrowserData() || !GetBrowserData()->IsRunning()) {
+    if (!GetBrowserData().IsRunning()) {
         return;
     }
 
@@ -29,22 +29,22 @@ void BrowserContext::Destroy()
 
 void BrowserContext::Resize(int32_t width, int32_t height)
 {
-    if (!GetBrowserData() || !GetBrowserData()->IsRunning()) {
+    if (!GetBrowserData().IsRunning()) {
         return;
     }
 
-    GetBrowserData()->SetSize(width, height);
+    GetBrowserData().SetSize(width, height);
 
     PerformResize();
 }
 
 void BrowserContext::Navigate(std::wstring destination)
 {
-    if (!GetBrowserData() || !GetBrowserData()->IsRunning() || destination.empty()) {
+    if (!GetBrowserData().IsRunning() || destination.empty()) {
         return;
     }
 
-    GetBrowserData()->SetDestination(std::move(destination));
+    GetBrowserData().SetDestination(std::move(destination));
 
     PerformNavigate();
 }

--- a/src/BrowserContext.hpp
+++ b/src/BrowserContext.hpp
@@ -18,7 +18,11 @@ class BrowserContext {
 public:
     virtual ~BrowserContext() = default;
 
-    [[nodiscard]] virtual BrowserData* GetBrowserData() const noexcept = 0;
+    /**
+     * Require implementors to provide their own implementation which exposes their
+     * platform specific implementations of Base::BrowserData
+     */
+    [[nodiscard]] virtual BrowserData& GetBrowserData() const noexcept = 0;
 
     /**
      * @brief Initialize the browser window by passing both the parent container and initial destination.
@@ -41,7 +45,7 @@ public:
     void Navigate(std::wstring);
 
 protected:
-    BrowserContext() noexcept = default;
+    explicit BrowserContext() noexcept = default;
 
 private:
     // Each platform is responsible for implementing the API

--- a/src/platform/linux/LinuxBrowserContext.cpp
+++ b/src/platform/linux/LinuxBrowserContext.cpp
@@ -5,23 +5,13 @@
 
 #include "LinuxBrowserContext.hpp"
 
-// static
-LinuxBrowserContext* LinuxBrowserContext::The()
-{
-    assert(Browser::The().GetBrowserContext() != nullptr);
-
-    // This method would only ever be available when working on Windows
-    //
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-    return static_cast<LinuxBrowserContext*>(Browser::The().GetBrowserContext());
-}
-
 LinuxBrowserContext::LinuxBrowserContext(std::unique_ptr<LinuxBrowserData> data) noexcept
     : m_data(std::move(data))
 {
+    assert(m_data != nullptr && "Expected browser data to exist!");
 }
 
-LinuxBrowserData* LinuxBrowserContext::GetBrowserData() const noexcept { return m_data.get(); }
+LinuxBrowserData& LinuxBrowserContext::GetBrowserData() const noexcept { return *m_data; }
 
 bool LinuxBrowserContext::PerformInitialize(JNIEnv* env, jobject canvas)
 {

--- a/src/platform/linux/LinuxBrowserContext.hpp
+++ b/src/platform/linux/LinuxBrowserContext.hpp
@@ -10,19 +10,10 @@
 
 class LinuxBrowserContext : public Base::BrowserContext {
 public:
-    /**
-     * We require a way to obtain the derived class from within the Windows
-     * context. This static method effectively passes through the context
-     * pointer provided by the Singleton Browser()
-     *
-     * For more information about the need for a singleton see Browser::The()
-     */
-    [[nodiscard]] static LinuxBrowserContext* The();
-
     explicit LinuxBrowserContext(std::unique_ptr<LinuxBrowserData>) noexcept;
     ~LinuxBrowserContext() override = default;
 
-    [[nodiscard]] LinuxBrowserData* GetBrowserData() const noexcept override;
+    [[nodiscard]] LinuxBrowserData& GetBrowserData() const noexcept override;
 
 private:
     // Platform specific methods

--- a/src/platform/windows/WebView2BrowserWindow.cpp
+++ b/src/platform/windows/WebView2BrowserWindow.cpp
@@ -173,9 +173,8 @@ HWND WebView2BrowserWindow::Create(HWND hostWindow)
         return nullptr;
     }
 
-    auto data = WindowsBrowserContext::The()->GetBrowserData();
-    auto height = data->GetHeight();
-    auto width = data->GetWidth();
+    auto height = WindowsBrowserContext::The()->GetBrowserData().GetHeight();
+    auto width = WindowsBrowserContext::The()->GetBrowserData().GetWidth();
 
     return CreateWindowEx(WS_EX_LEFT, WindowClassName, WindowName, WS_CHILDWINDOW | WS_VISIBLE, 0, 0, width, height,
         hostWindow, nullptr, instance, nullptr);
@@ -185,18 +184,18 @@ WebView2BrowserWindow::WebView2BrowserWindow(HWND parentWindow)
     : m_parentWindow(parentWindow)
 {
     if (!EnsureWebViewIsAvailable()) {
-        WindowsBrowserContext::The()->GetBrowserData()->SetState(ApplicationState::FAILED);
+        WindowsBrowserContext::The()->GetBrowserData().SetState(ApplicationState::FAILED);
 
         return;
     }
 
     if (!InitializeWebView()) {
-        WindowsBrowserContext::The()->GetBrowserData()->SetState(ApplicationState::FAILED);
+        WindowsBrowserContext::The()->GetBrowserData().SetState(ApplicationState::FAILED);
     } else {
         // We have successfully created our browser window and are prepared to start accepting
         // messages. At this point initialization has finished, and we can signal success back to
         // the caller
-        WindowsBrowserContext::The()->GetBrowserData()->SetState(ApplicationState::STARTED);
+        WindowsBrowserContext::The()->GetBrowserData().SetState(ApplicationState::STARTED);
     }
 }
 
@@ -256,7 +255,7 @@ void WebView2BrowserWindow::Destroy()
 {
     // At this point we are about to destroy the backing windows of the browser control. Any further calls to
     // exported functions will result in failures, so we must mark the browser control as pending.
-    WindowsBrowserContext::The()->GetBrowserData()->SetState(Base::ApplicationState::PENDING);
+    WindowsBrowserContext::The()->GetBrowserData().SetState(Base::ApplicationState::PENDING);
 
     SetParent(m_parentWindow, nullptr);
     DestroyWindow(m_parentWindow);
@@ -264,9 +263,8 @@ void WebView2BrowserWindow::Destroy()
 
 void WebView2BrowserWindow::Resize()
 {
-    auto data = WindowsBrowserContext::The()->GetBrowserData();
-    auto height = data->GetHeight();
-    auto width = data->GetWidth();
+    auto height = WindowsBrowserContext::The()->GetBrowserData().GetHeight();
+    auto width = WindowsBrowserContext::The()->GetBrowserData().GetWidth();
 
     SetWindowPos(
         m_parentWindow, nullptr, 0, 0, width, height, SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOMOVE | SWP_FRAMECHANGED);
@@ -282,6 +280,6 @@ void WebView2BrowserWindow::Resize()
 void WebView2BrowserWindow::Navigate()
 {
     if (m_webView != nullptr) {
-        m_webView->Navigate(WindowsBrowserContext::The()->GetBrowserData()->GetDestination().c_str());
+        m_webView->Navigate(WindowsBrowserContext::The()->GetBrowserData().GetDestination().c_str());
     }
 }

--- a/src/platform/windows/WindowsBrowserContext.cpp
+++ b/src/platform/windows/WindowsBrowserContext.cpp
@@ -21,6 +21,7 @@ WindowsBrowserContext* WindowsBrowserContext::The() noexcept
 WindowsBrowserContext::WindowsBrowserContext(std::unique_ptr<WindowsBrowserData> data)
     : m_data(std::move(data))
 {
+    assert(m_data != nullptr && "Expected browser data to exist!");
 }
 
 WindowsBrowserContext::~WindowsBrowserContext() noexcept
@@ -30,7 +31,7 @@ WindowsBrowserContext::~WindowsBrowserContext() noexcept
     }
 }
 
-WindowsBrowserData* WindowsBrowserContext::GetBrowserData() const noexcept { return m_data.get(); }
+WindowsBrowserData& WindowsBrowserContext::GetBrowserData() const noexcept { return *m_data; }
 
 bool WindowsBrowserContext::PerformInitialize(JNIEnv* env, jobject canvas)
 {

--- a/src/platform/windows/WindowsBrowserContext.hpp
+++ b/src/platform/windows/WindowsBrowserContext.hpp
@@ -20,7 +20,7 @@ public:
     explicit WindowsBrowserContext(std::unique_ptr<WindowsBrowserData>);
     ~WindowsBrowserContext() noexcept override;
 
-    [[nodiscard]] WindowsBrowserData* GetBrowserData() const noexcept override;
+    [[nodiscard]] WindowsBrowserData& GetBrowserData() const noexcept override;
 
 private:
     // Platform specific methods


### PR DESCRIPTION
We are certain that browser data is present when creating the context object. Because of that we can expose the data as a reference instead of a pointer.