### PR TITLE
windows: Remove WindowsBrowserContext::The()

### DIFF
--- a/src/platform/windows/WebView2BrowserWindow.hpp
+++ b/src/platform/windows/WebView2BrowserWindow.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "WindowsBrowserData.hpp"
+
 /**
  * @brief Implementation of a WebView2 browser window for displaying
  * advertisements within the AppletViewer.
@@ -21,9 +23,9 @@ public:
     }
     static HINSTANCE Register();
     static bool Unregister();
-    static HWND Create(HWND);
+    static HWND Create(WindowsBrowserData&);
 
-    explicit WebView2BrowserWindow(HWND);
+    explicit WebView2BrowserWindow(HWND, WindowsBrowserData&);
 
 private:
     static constexpr auto WindowClassName = L"Jb";
@@ -55,6 +57,7 @@ private:
     void Resize();
 
     HWND m_parentWindow;
+    WindowsBrowserData& m_data;
     wil::com_ptr<ICoreWebView2Controller> m_controller;
     wil::com_ptr<ICoreWebView2> m_webView;
 };

--- a/src/platform/windows/WindowsBrowserContext.cpp
+++ b/src/platform/windows/WindowsBrowserContext.cpp
@@ -7,17 +7,6 @@
 #include "WebView2BrowserWindow.hpp"
 #include "WindowsBrowserContext.hpp"
 
-// static
-WindowsBrowserContext* WindowsBrowserContext::The() noexcept
-{
-    assert(Browser::The().GetBrowserContext() != nullptr);
-
-    // This method would only ever be available when working on Windows
-    //
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
-    return static_cast<WindowsBrowserContext*>(Browser::The().GetBrowserContext());
-}
-
 WindowsBrowserContext::WindowsBrowserContext(std::unique_ptr<WindowsBrowserData> data)
     : m_data(std::move(data))
 {
@@ -57,7 +46,7 @@ void WindowsBrowserContext::StartMessagePump()
         goto handle_error;
     }
 
-    m_browserWindow = WebView2BrowserWindow::Create(m_data->GetHostWindow());
+    m_browserWindow = WebView2BrowserWindow::Create(GetBrowserData());
 
     if (m_browserWindow == nullptr) {
         goto handle_error;

--- a/src/platform/windows/WindowsBrowserContext.hpp
+++ b/src/platform/windows/WindowsBrowserContext.hpp
@@ -8,15 +8,6 @@
 
 class WindowsBrowserContext : public Base::BrowserContext {
 public:
-    /**
-     * We require a way to obtain the derived class from within the Windows
-     * context. This static method effectively passes through the context
-     * pointer provided by the Singleton Browser()
-     *
-     * For more information about the need for a singleton see Browser::The()
-     */
-    [[nodiscard]] static WindowsBrowserContext* The() noexcept;
-
     explicit WindowsBrowserContext(std::unique_ptr<WindowsBrowserData>);
     ~WindowsBrowserContext() noexcept override;
 


### PR DESCRIPTION
No need to expose a "singleton" reference to the browser context. Especially for Windows we can just pass the BrowserData to the WebView2BrowserWindow. It's not the cleanest since we need to use the weird Win32 APIs - but I'd like to use a similar approach for all platforms, and for Linux I think I can figure out a cleaner solution without having the Singleton The() method.