### PR TITLE
Linux: Create browser

### DIFF
--- a/src/BrowserContext.cpp
+++ b/src/BrowserContext.cpp
@@ -33,9 +33,9 @@ void BrowserContext::Resize(int32_t width, int32_t height)
         return;
     }
 
-    GetBrowserData().SetSize(width, height);
-
-    PerformResize();
+    if (GetBrowserData().SetSize(width, height)) {
+        PerformResize();
+    }
 }
 
 void BrowserContext::Navigate(std::wstring destination)

--- a/src/BrowserContext.hpp
+++ b/src/BrowserContext.hpp
@@ -19,12 +19,6 @@ public:
     virtual ~BrowserContext() = default;
 
     /**
-     * Require implementors to provide their own implementation which exposes their
-     * platform specific implementations of Base::BrowserData
-     */
-    [[nodiscard]] virtual BrowserData& GetBrowserData() const noexcept = 0;
-
-    /**
      * @brief Initialize the browser window by passing both the parent container and initial destination.
      *
      * It is the job of the browsercontrol library to fill the parent container with a web view
@@ -48,6 +42,12 @@ protected:
     explicit BrowserContext() noexcept = default;
 
 private:
+    /**
+     * Require implementors to provide their own implementation which exposes their
+     * platform specific implementations of Base::BrowserData
+     */
+    [[nodiscard]] virtual BrowserData& GetBrowserData() const noexcept = 0;
+
     // Each platform is responsible for implementing the API
     //
     // We expect these functions to reference `GetBrowserData` when

--- a/src/BrowserData.cpp
+++ b/src/BrowserData.cpp
@@ -43,11 +43,17 @@ void BrowserData::SetDestination(std::wstring destination) noexcept
     m_destination = std::move(destination);
 }
 
-void BrowserData::SetSize(int width, int height) noexcept
+bool BrowserData::SetSize(int width, int height) noexcept
 {
     std::lock_guard<std::mutex> lk(m_mutex);
 
+    if (width == m_size.first && height == m_size.second) {
+        return false;
+    }
+
     m_size = std::make_pair(width, height);
+
+    return true;
 }
 
 void BrowserData::SetState(Base::ApplicationState state) noexcept

--- a/src/BrowserData.hpp
+++ b/src/BrowserData.hpp
@@ -51,10 +51,13 @@ public:
      * on the user's machine we must first bootstrap it. During this process
      * this method will continue to report false. We only begin reporting
      * true once we have successfully bootstrapped the WebView2 process.
-     *
-     * Due to this, on Windows, there may be a small delay for the
+     * Due to this, there may be a small delay for the
      * AppletViewer the first time the user attempts to load the game if they
      * do *not* have WebView2 installed from a previous application.
+     *
+     * On Linux, we report when we have initialized CEF, but due to CEF requiring
+     * a non-zero height/width, we must wait until the subsequent call to `resize()`
+     * to perform browser window creation.
      *
      * @return True if we have received signs of life from the browser
      * process.
@@ -67,7 +70,17 @@ public:
      * dll caller as well as the web view.
      */
     void SetDestination(std::wstring) noexcept;
-    void SetSize(int, int) noexcept;
+    /**
+     * Check if the provided size is different than the current size,
+     * if it is store the new size, otherwise do nothing.
+     *
+     * This is useful due to the resize method being called from the Java
+     * side on every resize event, even through the browsercontrol window
+     * itself is bounded by strict width/height rules.
+     *
+     * @return True if we stored a new size, false if we did not.
+     */
+    [[nodiscard]] bool SetSize(int, int) noexcept;
     void SetState(ApplicationState) noexcept;
 
     void WaitForStateOrFailure(ApplicationState) noexcept;

--- a/src/BrowserData.hpp
+++ b/src/BrowserData.hpp
@@ -36,8 +36,6 @@ enum class ApplicationState : uint8_t {
 
 class BrowserData {
 public:
-    virtual ~BrowserData() = default;
-
     [[nodiscard]] const std::wstring& GetDestination() const noexcept;
     [[nodiscard]] int GetWidth() const noexcept;
     [[nodiscard]] int GetHeight() const noexcept;
@@ -86,6 +84,7 @@ public:
 
 protected:
     BrowserData() = default;
+    virtual ~BrowserData() = default;
 
     mutable std::mutex m_mutex;
 

--- a/src/BrowserData.hpp
+++ b/src/BrowserData.hpp
@@ -62,16 +62,6 @@ public:
     [[nodiscard]] bool IsRunning() const noexcept;
 
     /**
-     * Resolve the working directory of the parent application.
-     *
-     * In the case of Linux this will point to the location of the CEF library assets
-     * and helper executable.
-     *
-     * By default this will an empty path for platforms which don't require this information.
-     */
-    [[nodiscard]] virtual std::filesystem::path ResolveWorkingDirectory(JNIEnv*) noexcept { return {}; }
-
-    /**
      * Setting the destination does not perform any validation about the
      * validity or security of a particular URL. This is left up to the
      * dll caller as well as the web view.

--- a/src/platform/linux/BrowserApp.cpp
+++ b/src/platform/linux/BrowserApp.cpp
@@ -2,7 +2,7 @@
 
 #include "BrowserApp.hpp"
 
-BrowserApp::BrowserApp(BrowserApp::Delegate& delegate)
+BrowserApp::BrowserApp(const BrowserApp::Delegate& delegate)
     : m_delegate(delegate)
 {
 }

--- a/src/platform/linux/BrowserApp.cpp
+++ b/src/platform/linux/BrowserApp.cpp
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "BrowserApp.hpp"
+
+void BrowserApp::OnBeforeCommandLineProcessing(const CefString& processType, CefRefPtr<CefCommandLine> commandLine)
+{
+    commandLine->AppendSwitch("--disable-extensions");
+}

--- a/src/platform/linux/BrowserApp.cpp
+++ b/src/platform/linux/BrowserApp.cpp
@@ -2,7 +2,14 @@
 
 #include "BrowserApp.hpp"
 
+BrowserApp::BrowserApp(BrowserApp::Delegate& delegate)
+    : m_delegate(delegate)
+{
+}
+
 void BrowserApp::OnBeforeCommandLineProcessing(const CefString& processType, CefRefPtr<CefCommandLine> commandLine)
 {
     commandLine->AppendSwitch("--disable-extensions");
 }
+
+void BrowserApp::OnContextInitialized() { m_delegate.OnContextInitialized(); }

--- a/src/platform/linux/BrowserApp.hpp
+++ b/src/platform/linux/BrowserApp.hpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#pragma once
+
+#include <include/base/cef_ref_counted.h>
+#include <include/cef_app.h>
+
+/**
+ * Provides the BrowserProcess implementation of CefApp.
+ *
+ * This is not shared with any other process, we defer to
+ * CEF's default implementation for the other processes, and
+ * that logic is handled in the helper.
+ *
+ * Honestly we don't use CefApp for much here, just some
+ * logic within `OnBeforeCommandLineProcessing`
+ */
+class BrowserApp : public CefApp, public CefBrowserProcessHandler {
+public:
+    BrowserApp() = default;
+    ~BrowserApp() override = default;
+
+    // CefApp overrides
+    CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override { return this; }
+
+    // CefBrowserProcessHandler overrides
+    void OnBeforeCommandLineProcessing(const CefString&, CefRefPtr<CefCommandLine>) override;
+
+    IMPLEMENT_REFCOUNTING(BrowserApp);
+};

--- a/src/platform/linux/BrowserApp.hpp
+++ b/src/platform/linux/BrowserApp.hpp
@@ -27,10 +27,10 @@ public:
          * has been initialized and we can begin the creation
          * of the browser window.
          */
-        virtual void OnContextInitialized() = 0;
+        virtual void OnContextInitialized() const = 0;
     };
 
-    explicit BrowserApp(Delegate&);
+    explicit BrowserApp(const Delegate&);
     ~BrowserApp() override = default;
 
     // CefApp overrides
@@ -43,5 +43,5 @@ public:
     IMPLEMENT_REFCOUNTING(BrowserApp);
 
 private:
-    Delegate& m_delegate;
+    const Delegate& m_delegate;
 };

--- a/src/platform/linux/BrowserApp.hpp
+++ b/src/platform/linux/BrowserApp.hpp
@@ -11,13 +11,26 @@
  * This is not shared with any other process, we defer to
  * CEF's default implementation for the other processes, and
  * that logic is handled in the helper.
- *
- * Honestly we don't use CefApp for much here, just some
- * logic within `OnBeforeCommandLineProcessing`
  */
 class BrowserApp : public CefApp, public CefBrowserProcessHandler {
 public:
-    BrowserApp() = default;
+    /**
+     * Provides a simple interface for classes which will
+     * receive events during browser initialization.
+     *
+     * We are only interested in the `OnContextInitialized` callback
+     * from `CefBrowserProcessHandler`.
+     */
+    struct Delegate {
+        /**
+         * Once this method has been called we know that CEF
+         * has been initialized and we can begin the creation
+         * of the browser window.
+         */
+        virtual void OnContextInitialized() = 0;
+    };
+
+    explicit BrowserApp(Delegate&);
     ~BrowserApp() override = default;
 
     // CefApp overrides
@@ -25,6 +38,10 @@ public:
 
     // CefBrowserProcessHandler overrides
     void OnBeforeCommandLineProcessing(const CefString&, CefRefPtr<CefCommandLine>) override;
+    void OnContextInitialized() override;
 
     IMPLEMENT_REFCOUNTING(BrowserApp);
+
+private:
+    Delegate& m_delegate;
 };

--- a/src/platform/linux/BrowserEventLoop.cpp
+++ b/src/platform/linux/BrowserEventLoop.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "BrowserEventLoop.hpp"
+
+BrowserEventLoop::BrowserEventLoop()
+    : m_isRunning(true)
+    , m_thread { &BrowserEventLoop::ThreadWorker, this }
+{
+}
+
+BrowserEventLoop::~BrowserEventLoop() noexcept
+{
+    // clang-format off
+    //
+    // base::Unretained is safe here due to our call to `m_thread.join()` which
+    // will block until all outstanding work is completed, thus our this pointer
+    // wil continue to be valid until after the call to base::OnceClosure::Run is
+    // executed.
+    EnqueueWork(base::BindOnce(
+        [](BrowserEventLoop* self) { self->m_isRunning = false; },
+        base::Unretained(this))
+    );
+    // clang-format on
+
+    m_thread.join();
+}
+
+void BrowserEventLoop::EnqueueWork(base::OnceClosure&& work) noexcept
+{
+    {
+        std::lock_guard<std::mutex> guard(m_mutex);
+        m_work.emplace_back(std::move(work));
+    }
+
+    m_cv.notify_one();
+}
+
+void BrowserEventLoop::ThreadWorker() noexcept
+{
+    std::vector<base::OnceClosure> currentWork;
+
+    while (m_isRunning) {
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            m_cv.wait(lock, [this] { return !m_work.empty(); });
+
+            std::swap(currentWork, m_work);
+        }
+
+        for (base::OnceClosure& work : currentWork) {
+            if (work.is_null()) {
+                continue;
+            }
+
+            std::move(work).Run();
+        }
+
+        currentWork.clear();
+    }
+}

--- a/src/platform/linux/BrowserEventLoop.cpp
+++ b/src/platform/linux/BrowserEventLoop.cpp
@@ -25,6 +25,11 @@ BrowserEventLoop::~BrowserEventLoop() noexcept
     m_thread.join();
 }
 
+bool BrowserEventLoop::CurrentlyOnBrowserThread() const noexcept
+{
+    return std::this_thread::get_id() == m_thread.get_id();
+}
+
 void BrowserEventLoop::EnqueueWork(base::OnceClosure&& work) noexcept
 {
     {

--- a/src/platform/linux/BrowserEventLoop.cpp
+++ b/src/platform/linux/BrowserEventLoop.cpp
@@ -42,7 +42,7 @@ void BrowserEventLoop::EnqueueWork(base::OnceClosure&& work) noexcept
 void BrowserEventLoop::ThreadWorker() noexcept
 {
     // Will bind the ThreadChecker to this thread.
-    DCHECK(m_threadChecker.CalledOnValidThread());
+    // DCHECK(m_threadChecker.CalledOnValidThread());
 
     std::vector<base::OnceClosure> currentWork;
 

--- a/src/platform/linux/BrowserEventLoop.cpp
+++ b/src/platform/linux/BrowserEventLoop.cpp
@@ -42,7 +42,7 @@ void BrowserEventLoop::EnqueueWork(base::OnceClosure&& work) noexcept
 void BrowserEventLoop::ThreadWorker() noexcept
 {
     // Will bind the ThreadChecker to this thread.
-    // DCHECK(m_threadChecker.CalledOnValidThread());
+    m_threadChecker.CalledOnValidThread();
 
     std::vector<base::OnceClosure> currentWork;
 

--- a/src/platform/linux/BrowserEventLoop.hpp
+++ b/src/platform/linux/BrowserEventLoop.hpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#pragma once
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <include/base/cef_callback.h>
+
+/**
+ * Allows for logic from multiple threads to have the ability to post work to the
+ * main application thread.
+ *
+ * This is required due to CEF having strict requirements that the same thread which
+ * called `CefInitialize` is also being used to call other main methods.
+ *
+ * Also, due to the API exposed by the browsercontrol library, we must utilize the
+ * `multi_threaded_message_loop` which forces us to have some way of posting tasks
+ * to the thread hosting the message loop.
+ */
+class BrowserEventLoop {
+public:
+    BrowserEventLoop();
+
+    BrowserEventLoop(const BrowserEventLoop&) = delete;
+    BrowserEventLoop(BrowserEventLoop&&) noexcept = delete;
+
+    BrowserEventLoop& operator=(const BrowserEventLoop&) = delete;
+    BrowserEventLoop& operator=(BrowserEventLoop&&) noexcept = delete;
+
+    /**
+     * Enqueue work to be performed on the browser process thread.
+     *
+     * @example BrowserEventLoop::EnqueueWork(base::BindOnce(...));
+     */
+    void EnqueueWork(base::OnceClosure&&) noexcept;
+
+protected:
+    // Allow deletion by std::unique_ptr only
+    friend std::default_delete<BrowserEventLoop>;
+
+    ~BrowserEventLoop();
+
+private:
+    std::vector<base::OnceClosure> m_work;
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+    bool m_isRunning;
+    std::thread m_thread;
+
+    void ThreadWorker() noexcept;
+};

--- a/src/platform/linux/BrowserEventLoop.hpp
+++ b/src/platform/linux/BrowserEventLoop.hpp
@@ -32,19 +32,24 @@ public:
     BrowserEventLoop& operator=(BrowserEventLoop&&) noexcept = delete;
 
     /**
+     * Provide ability to query if the current thread is the main worker
+     * thread.
+     */
+    [[nodiscard]] bool CurrentlyOnBrowserThread() const noexcept;
+
+    /**
      * Enqueue work to be performed on the browser process thread.
      *
      * @example BrowserEventLoop::EnqueueWork(base::BindOnce(...));
      */
     void EnqueueWork(base::OnceClosure&&) noexcept;
 
-protected:
+private:
     // Allow deletion by std::unique_ptr only
     friend std::default_delete<BrowserEventLoop>;
 
     ~BrowserEventLoop();
 
-private:
     std::vector<base::OnceClosure> m_work;
     std::mutex m_mutex;
     std::condition_variable m_cv;

--- a/src/platform/linux/BrowserEventLoop.hpp
+++ b/src/platform/linux/BrowserEventLoop.hpp
@@ -50,6 +50,7 @@ private:
 
     ~BrowserEventLoop();
 
+    base::ThreadChecker m_threadChecker;
     std::vector<base::OnceClosure> m_work;
     std::mutex m_mutex;
     std::condition_variable m_cv;

--- a/src/platform/linux/BrowserHandler.cpp
+++ b/src/platform/linux/BrowserHandler.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "BrowserHandler.hpp"
+
+BrowserHandler::BrowserHandler(BrowserHandler::Delegate& delegate) noexcept
+    : m_delegate(delegate)
+{
+}
+
+void BrowserHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser) { m_delegate.OnBrowserCreated(browser); }
+
+void BrowserHandler::OnBeforeClose(CefRefPtr<CefBrowser> browser) { }

--- a/src/platform/linux/BrowserHandler.hpp
+++ b/src/platform/linux/BrowserHandler.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#pragma once
+
+#include <include/cef_client.h>
+
+class BrowserHandler : public CefClient, public CefLifeSpanHandler {
+public:
+    struct Delegate {
+        virtual void OnBrowserCreated(CefRefPtr<CefBrowser>) = 0;
+    };
+
+    explicit BrowserHandler(Delegate&) noexcept;
+
+    // CefLifeSpanHandler methods
+    CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }
+    void OnAfterCreated(CefRefPtr<CefBrowser>) override;
+    void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
+
+private:
+    Delegate& m_delegate;
+
+    IMPLEMENT_REFCOUNTING(BrowserHandler);
+};

--- a/src/platform/linux/BrowserWindow.cpp
+++ b/src/platform/linux/BrowserWindow.cpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <include/cef_base.h>
+
+#include "BrowserWindow.hpp"
+
+BrowserWindow::BrowserWindow(LinuxBrowserData& data, BrowserEventLoop& eventLoop) noexcept
+    : m_data(data)
+    , m_eventLoop(eventLoop) // TODO: Verify we need to pass this
+{
+}
+
+bool BrowserWindow::CreateHostWindow()
+{
+    DCHECK(m_eventLoop.CurrentlyOnBrowserThread());
+    DCHECK(m_displayConnection.MakeConnection());
+
+    return true;
+}

--- a/src/platform/linux/BrowserWindow.cpp
+++ b/src/platform/linux/BrowserWindow.cpp
@@ -4,15 +4,13 @@
 
 #include "BrowserWindow.hpp"
 
-BrowserWindow::BrowserWindow(LinuxBrowserData& data, BrowserEventLoop& eventLoop) noexcept
+BrowserWindow::BrowserWindow(LinuxBrowserData& data) noexcept
     : m_data(data)
-    , m_eventLoop(eventLoop) // TODO: Verify we need to pass this
 {
 }
 
 bool BrowserWindow::CreateHostWindow()
 {
-    DCHECK(m_eventLoop.CurrentlyOnBrowserThread());
     DCHECK(m_displayConnection.MakeConnection());
 
     return true;

--- a/src/platform/linux/BrowserWindow.cpp
+++ b/src/platform/linux/BrowserWindow.cpp
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
+#include <include/base/cef_bind.h>
+
 #include "BrowserWindow.hpp"
 
-BrowserWindow::BrowserWindow(LinuxBrowserData& data) noexcept
-    : m_containerWindow(ContainerWindow(*this))
+BrowserWindow::BrowserWindow(LinuxBrowserData& data, BrowserEventLoop& eventLoop) noexcept
+    : m_clientHandler(new BrowserHandler(*this))
+    , m_containerWindow(ContainerWindow(*this))
+    , m_eventLoop(eventLoop)
     , m_data(data)
 {
 }
@@ -19,4 +23,42 @@ bool BrowserWindow::Create()
     }
 
     return true;
+}
+
+void BrowserWindow::OnBrowserCreated(CefRefPtr<CefBrowser> browser)
+{
+    if (!m_eventLoop.CurrentlyOnBrowserThread()) {
+        m_eventLoop.EnqueueWork(base::BindOnce(&BrowserWindow::OnBrowserCreated, base::Unretained(this), browser));
+
+        return;
+    }
+
+    if (!m_browser) {
+        m_browser = browser;
+    }
+
+    m_data.SetState(Base::ApplicationState::STARTED);
+}
+
+void BrowserWindow::OnContainerWindowCreate(xcb_window_t containerWindow) const
+{
+    if (!m_eventLoop.CurrentlyOnBrowserThread()) {
+        m_eventLoop.EnqueueWork(
+            base::BindOnce(&BrowserWindow::OnContainerWindowCreate, base::Unretained(this), containerWindow));
+
+        return;
+    }
+
+    CefBrowserSettings browserSettings;
+    CefWindowInfo windowInfo;
+    windowInfo.SetAsChild(m_containerWindow.GetWindowHandle(), CefRect(0, 0, m_data.GetWidth(), m_data.GetHeight()));
+
+    bool result = CefBrowserHost::CreateBrowser(
+        windowInfo, m_clientHandler.get(), m_data.GetDestination(), browserSettings, nullptr, nullptr);
+
+    if (!result) {
+        m_data.SetState(Base::ApplicationState::FAILED);
+
+        return;
+    }
 }

--- a/src/platform/linux/BrowserWindow.cpp
+++ b/src/platform/linux/BrowserWindow.cpp
@@ -1,17 +1,22 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-#include <include/cef_base.h>
-
 #include "BrowserWindow.hpp"
 
 BrowserWindow::BrowserWindow(LinuxBrowserData& data) noexcept
-    : m_data(data)
+    : m_containerWindow(ContainerWindow(*this))
+    , m_data(data)
 {
 }
 
-bool BrowserWindow::CreateHostWindow()
+bool BrowserWindow::Create()
 {
-    DCHECK(m_displayConnection.MakeConnection());
+    if (!m_containerWindow.MakeXConnection()) {
+        return false;
+    }
+
+    if (!m_containerWindow.Create(m_data.GetHostWindow())) {
+        return false;
+    }
 
     return true;
 }

--- a/src/platform/linux/BrowserWindow.hpp
+++ b/src/platform/linux/BrowserWindow.hpp
@@ -2,91 +2,17 @@
 
 #pragma once
 
-#include <xcb/xcb.h>
-
 #include "BrowserEventLoop.hpp"
+#include "ContainerWindow.hpp"
 #include "LinuxBrowserData.hpp"
 
-class DisplayConnection {
-public:
-    DisplayConnection() = default;
-
-    ~DisplayConnection() noexcept
-    {
-        if (m_connection) {
-            xcb_disconnect(m_connection);
-        }
-    }
-
-    bool MakeConnection() noexcept
-    {
-        int preferredScreen = 0;
-        m_connection = Connect(&preferredScreen);
-
-        if (!m_connection) {
-            return false;
-        }
-
-        m_screen = FindPreferredScreen(m_connection, preferredScreen);
-
-        if (!m_screen) {
-            return false;
-        }
-
-        return true;
-    }
-
-private:
-    static xcb_connection_t* Connect(int* screen)
-    {
-        xcb_connection_t* connection = xcb_connect(nullptr, screen);
-
-        int connection_error = xcb_connection_has_error(connection);
-
-        if (connection_error) {
-            // Still need to free connection
-            xcb_disconnect(connection);
-
-            return nullptr;
-        }
-
-        return connection;
-    }
-
-    /**
-     * Find the preferred screen, as identified by `xcb_connect`.
-     *
-     * When calling `xcb_connect` we are passed a preferred screen number. By default this is `0`
-     * but in the case this is something else we will iterate over the available screens
-     * and return back the one which was requested.
-     */
-    static xcb_screen_t* FindPreferredScreen(xcb_connection_t* connection, int preferredScreen)
-    {
-        int currentScreen = 0;
-
-        for (xcb_screen_iterator_t it = xcb_setup_roots_iterator(xcb_get_setup(connection)); it.rem;
-             xcb_screen_next(&it)) {
-            if (currentScreen == preferredScreen) {
-                return it.data;
-            }
-
-            ++currentScreen;
-        }
-
-        return nullptr;
-    }
-
-    xcb_connection_t* m_connection;
-    xcb_screen_t* m_screen;
-};
-
-class BrowserWindow {
+class BrowserWindow : private ContainerWindow::Delegate {
 public:
     explicit BrowserWindow(LinuxBrowserData&) noexcept;
 
-    bool CreateHostWindow();
+    [[nodiscard]] bool Create();
 
 private:
-    DisplayConnection m_displayConnection;
+    ContainerWindow m_containerWindow;
     LinuxBrowserData& m_data;
 };

--- a/src/platform/linux/BrowserWindow.hpp
+++ b/src/platform/linux/BrowserWindow.hpp
@@ -2,17 +2,31 @@
 
 #pragma once
 
+#include <xcb/xcb.h>
+
+#include <include/cef_browser.h>
+#include <include/cef_client.h>
+
 #include "BrowserEventLoop.hpp"
+#include "BrowserHandler.hpp"
 #include "ContainerWindow.hpp"
 #include "LinuxBrowserData.hpp"
 
-class BrowserWindow : private ContainerWindow::Delegate {
+class BrowserWindow : private BrowserHandler::Delegate, private ContainerWindow::Delegate {
 public:
-    explicit BrowserWindow(LinuxBrowserData&) noexcept;
+    explicit BrowserWindow(LinuxBrowserData&, BrowserEventLoop&) noexcept;
 
     [[nodiscard]] bool Create();
 
+    // BrowserWindow::Delegate methods
+    void OnBrowserCreated(CefRefPtr<CefBrowser>) override;
+    // ContainerWindow::Delegate methods
+    void OnContainerWindowCreate(xcb_window_t) const override;
+
 private:
+    CefRefPtr<CefBrowser> m_browser;
+    CefRefPtr<CefClient> m_clientHandler;
     ContainerWindow m_containerWindow;
+    BrowserEventLoop& m_eventLoop;
     LinuxBrowserData& m_data;
 };

--- a/src/platform/linux/BrowserWindow.hpp
+++ b/src/platform/linux/BrowserWindow.hpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#pragma once
+
+#include <xcb/xcb.h>
+
+#include "BrowserEventLoop.hpp"
+#include "LinuxBrowserData.hpp"
+
+class DisplayConnection {
+public:
+    DisplayConnection() = default;
+
+    ~DisplayConnection() noexcept
+    {
+        if (m_connection) {
+            xcb_disconnect(m_connection);
+        }
+    }
+
+    bool MakeConnection() noexcept
+    {
+        int preferredScreen = 0;
+        m_connection = Connect(&preferredScreen);
+
+        if (!m_connection) {
+            return false;
+        }
+
+        m_screen = FindPreferredScreen(m_connection, preferredScreen);
+
+        if (!m_screen) {
+            return false;
+        }
+
+        return true;
+    }
+
+private:
+    static xcb_connection_t* Connect(int* screen)
+    {
+        xcb_connection_t* connection = xcb_connect(nullptr, screen);
+
+        int connection_error = xcb_connection_has_error(connection);
+
+        if (connection_error) {
+            // Still need to free connection
+            xcb_disconnect(connection);
+
+            return nullptr;
+        }
+
+        return connection;
+    }
+
+    /**
+     * Find the preferred screen, as identified by `xcb_connect`.
+     *
+     * When calling `xcb_connect` we are passed a preferred screen number. By default this is `0`
+     * but in the case this is something else we will iterate over the available screens
+     * and return back the one which was requested.
+     */
+    static xcb_screen_t* FindPreferredScreen(xcb_connection_t* connection, int preferredScreen)
+    {
+        int currentScreen = 0;
+
+        for (xcb_screen_iterator_t it = xcb_setup_roots_iterator(xcb_get_setup(connection)); it.rem;
+             xcb_screen_next(&it)) {
+            if (currentScreen == preferredScreen) {
+                return it.data;
+            }
+
+            ++currentScreen;
+        }
+
+        return nullptr;
+    }
+
+    xcb_connection_t* m_connection;
+    xcb_screen_t* m_screen;
+};
+
+class BrowserWindow {
+public:
+    explicit BrowserWindow(LinuxBrowserData&, BrowserEventLoop&) noexcept;
+
+    bool CreateHostWindow();
+
+private:
+    DisplayConnection m_displayConnection;
+    LinuxBrowserData& m_data;
+    BrowserEventLoop& m_eventLoop;
+};

--- a/src/platform/linux/BrowserWindow.hpp
+++ b/src/platform/linux/BrowserWindow.hpp
@@ -82,12 +82,11 @@ private:
 
 class BrowserWindow {
 public:
-    explicit BrowserWindow(LinuxBrowserData&, BrowserEventLoop&) noexcept;
+    explicit BrowserWindow(LinuxBrowserData&) noexcept;
 
     bool CreateHostWindow();
 
 private:
     DisplayConnection m_displayConnection;
     LinuxBrowserData& m_data;
-    BrowserEventLoop& m_eventLoop;
 };

--- a/src/platform/linux/CMakeLists.txt
+++ b/src/platform/linux/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(
   BrowserApp.cpp
   BrowserEventLoop.cpp
   BrowserWindow.cpp
+  ContainerWindow.cpp
   JVMSignals.cpp
   LinuxBrowserContext.cpp
   LinuxBrowserData.cpp

--- a/src/platform/linux/CMakeLists.txt
+++ b/src/platform/linux/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
   init.cpp
   BrowserApp.cpp
   BrowserEventLoop.cpp
+  BrowserWindow.cpp
   JVMSignals.cpp
   LinuxBrowserContext.cpp
   LinuxBrowserData.cpp
@@ -44,8 +45,10 @@ add_library(
 target_precompile_headers(browsercontrol PRIVATE pch.hpp)
 set_library_target_properties(browsercontrol)
 add_dependencies(browsercontrol libcef_dll_wrapper)
-target_include_directories(browsercontrol PUBLIC ${CMAKE_SOURCE_DIR} ${JNI_INCLUDE_DIRS})
-target_link_libraries(browsercontrol libcef_lib libcef_dll_wrapper ${JNI_LIBRARIES} ${CEF_STANDARD_LIBS})
+target_link_libraries(
+  browsercontrol libcef_lib libcef_dll_wrapper ${JNI_LIBRARIES} ${XCB_LIBRARIES} ${CEF_STANDARD_LIBS}
+)
+target_include_directories(browsercontrol PUBLIC ${CMAKE_SOURCE_DIR} ${XCB_INCLUDE_DIRS} ${JNI_INCLUDE_DIRS})
 set_browsercontrol_target_properties(browsercontrol)
 
 # Helper executable target

--- a/src/platform/linux/CMakeLists.txt
+++ b/src/platform/linux/CMakeLists.txt
@@ -32,7 +32,14 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CEF_TARGET_OUT_DIR})
 
 # Library target
 add_library(
-        browsercontrol SHARED ${BROWSERCONTROL_SHARED_SOURCES} init.cpp BrowserEventLoop.cpp LinuxBrowserContext.cpp LinuxBrowserData.cpp
+  browsercontrol SHARED
+  ${BROWSERCONTROL_SHARED_SOURCES}
+  init.cpp
+  BrowserApp.cpp
+  BrowserEventLoop.cpp
+  JVMSignals.cpp
+  LinuxBrowserContext.cpp
+  LinuxBrowserData.cpp
 )
 target_precompile_headers(browsercontrol PRIVATE pch.hpp)
 set_library_target_properties(browsercontrol)

--- a/src/platform/linux/CMakeLists.txt
+++ b/src/platform/linux/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
   init.cpp
   BrowserApp.cpp
   BrowserEventLoop.cpp
+  BrowserHandler.cpp
   BrowserWindow.cpp
   ContainerWindow.cpp
   JVMSignals.cpp

--- a/src/platform/linux/CMakeLists.txt
+++ b/src/platform/linux/CMakeLists.txt
@@ -32,7 +32,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CEF_TARGET_OUT_DIR})
 
 # Library target
 add_library(
-        browsercontrol SHARED ${BROWSERCONTROL_SHARED_SOURCES} init.cpp LinuxBrowserContext.cpp LinuxBrowserData.cpp
+        browsercontrol SHARED ${BROWSERCONTROL_SHARED_SOURCES} init.cpp BrowserEventLoop.cpp LinuxBrowserContext.cpp LinuxBrowserData.cpp
 )
 target_precompile_headers(browsercontrol PRIVATE pch.hpp)
 set_library_target_properties(browsercontrol)

--- a/src/platform/linux/ContainerWindow.cpp
+++ b/src/platform/linux/ContainerWindow.cpp
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <ctime>
+#include <iostream>
+#include <sys/select.h>
+
+#include "ContainerWindow.hpp"
+
+namespace {
+
+constexpr auto HOST_WINDOW_NAME = "jbw";
+
+}
+
+ContainerWindow::ContainerWindow(const ContainerWindow::Delegate& delegate) noexcept
+    : m_delegate(delegate)
+    , m_connection(nullptr)
+    , m_screen(nullptr)
+    , m_window(XCB_NONE)
+    , m_wmDeleteWindowAtom(XCB_NONE)
+{
+}
+
+ContainerWindow::~ContainerWindow()
+{
+    if (m_connection != nullptr) {
+        xcb_destroy_window(m_connection, m_window);
+
+        xcb_flush(m_connection);
+    }
+
+    if (m_status == EventLoopStatus::RUNNING) {
+        m_status = EventLoopStatus::STOPPED;
+    }
+
+    if (m_eventLoopThread && m_eventLoopThread->joinable()) {
+        m_eventLoopThread->join();
+    }
+
+    if (m_wmDeleteWindowAtom != XCB_NONE) {
+        free(m_wmDeleteWindowAtom);
+    }
+
+    xcb_disconnect(m_connection);
+}
+
+bool ContainerWindow::Create(xcb_window_t hostWindow)
+{
+    m_window = xcb_generate_id(m_connection);
+
+    uint16_t mask = XCB_CW_EVENT_MASK;
+    const uint32_t values[] = { XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY };
+
+    xcb_create_window(m_connection, XCB_COPY_FROM_PARENT, m_window, hostWindow, 0, 0, 1014, 96, 0,
+        XCB_WINDOW_CLASS_INPUT_OUTPUT, m_screen->root_visual, mask, values);
+
+    xcb_change_property(m_connection, XCB_PROP_MODE_REPLACE, m_window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 8,
+        std::strlen(HOST_WINDOW_NAME), HOST_WINDOW_NAME);
+
+    auto wmProtocolsCookie = xcb_intern_atom(m_connection, 1, 12, "WM_PROTOCOLS");
+    auto* wmProtocolsReply = xcb_intern_atom_reply(m_connection, wmProtocolsCookie, nullptr);
+
+    if (wmProtocolsReply == XCB_NONE) {
+        return false;
+    }
+
+    auto wmDeleteWindowCookie = xcb_intern_atom(m_connection, 1, 12, "WM_DELETE_WINDOW");
+
+    // Store delete atom for later reference
+    m_wmDeleteWindowAtom = xcb_intern_atom_reply(m_connection, wmDeleteWindowCookie, nullptr);
+
+    if (m_wmDeleteWindowAtom == XCB_NONE) {
+        free(wmProtocolsReply);
+
+        return false;
+    }
+
+    xcb_map_window(m_connection, m_window);
+
+    xcb_flush(m_connection);
+
+    return true;
+}
+
+xcb_window_t ContainerWindow::GetWindowHandle() const noexcept { return m_window; }
+
+bool ContainerWindow::MakeXConnection() noexcept
+{
+    int preferredScreen = 0;
+    m_connection = Connect(&preferredScreen);
+
+    if (!m_connection) {
+        return false;
+    }
+
+    m_screen = FindPreferredScreen(m_connection, preferredScreen);
+
+    if (!m_screen) {
+        return false;
+    }
+
+    StartEventLoop();
+
+    return true;
+}
+
+void ContainerWindow::StartEventLoop()
+{
+    if (m_status == EventLoopStatus::RUNNING || m_eventLoopThread != nullptr) {
+        return;
+    }
+
+    m_status = EventLoopStatus::RUNNING;
+
+    m_eventLoopThread = std::make_unique<std::thread>(&ContainerWindow::EventLoop, this);
+}
+
+void ContainerWindow::StopEventLoop() { m_status = EventLoopStatus::STOPPED; }
+
+// static
+xcb_connection_t* ContainerWindow::Connect(int* screen)
+{
+    xcb_connection_t* connection = xcb_connect(nullptr, screen);
+
+    int connection_error = xcb_connection_has_error(connection);
+
+    if (connection_error) {
+        // Still need to free connection
+        xcb_disconnect(connection);
+
+        return nullptr;
+    }
+
+    return connection;
+}
+
+// static
+xcb_screen_t* ContainerWindow::FindPreferredScreen(xcb_connection_t* connection, int preferredScreen)
+{
+    const xcb_setup_t* setup = xcb_get_setup(connection);
+    xcb_screen_iterator_t itr = xcb_setup_roots_iterator(setup);
+
+    for (int i = 0; itr.rem; ++i, xcb_screen_next(&itr)) {
+        if (i == preferredScreen) {
+            return itr.data;
+        }
+    }
+
+    return nullptr;
+}
+
+void ContainerWindow::EventLoop()
+{
+    fd_set fds;
+    int xcb_fd = xcb_get_file_descriptor(m_connection);
+
+    // If there hasn't been an X event in 25 milliseconds then we time out
+    // and check for interrupts or errors
+    struct timespec ts = { .tv_sec = 0, .tv_nsec = 25000000 };
+
+    xcb_generic_event_t* event = XCB_NONE;
+    while (m_status == EventLoopStatus::RUNNING) {
+        FD_ZERO(&fds);
+        FD_SET(xcb_fd, &fds);
+
+        if (xcb_connection_has_error(m_connection) && m_status == EventLoopStatus::RUNNING) {
+            // TODO: handle error
+            return;
+        }
+
+        int eventCount = pselect(xcb_fd + 1, &fds, nullptr, nullptr, &ts, nullptr);
+
+        if (eventCount < 0) {
+            // pselect failed
+
+            // TODO: Handle error
+            return;
+        }
+
+        if (eventCount == 0) {
+            // Nothing to process
+            continue;
+        }
+
+        while ((event = xcb_poll_for_event(m_connection))) {
+            ProcessXEvent(*event);
+
+            free(event);
+            xcb_flush(m_connection);
+        }
+    }
+}
+
+bool ContainerWindow::ProcessXEvent(const xcb_generic_event_t& event) const
+{
+    if (event.response_type == 0) {
+        // Handle errors from unchecked functions
+        auto error = reinterpret_cast<const xcb_generic_error_t&>(event);
+
+        std::cout << error.error_code << '\n';
+        return false;
+    }
+
+    auto code = event.response_type & ~0x80;
+
+    switch (code) {
+    case XCB_CLIENT_MESSAGE:
+        std::cout << "Client message" << '\n';
+        return true;
+    case XCB_DESTROY_NOTIFY:
+        std::cout << "Destroy notify" << '\n';
+        return true;
+    }
+
+    return true;
+}

--- a/src/platform/linux/ContainerWindow.hpp
+++ b/src/platform/linux/ContainerWindow.hpp
@@ -6,7 +6,9 @@
 
 class ContainerWindow {
 public:
-    class Delegate { };
+    struct Delegate {
+        virtual void OnContainerWindowCreate(xcb_window_t) const = 0;
+    };
 
     explicit ContainerWindow(const Delegate&) noexcept;
 
@@ -24,7 +26,7 @@ public:
      *
      * @return The X window handle
      */
-    xcb_window_t GetWindowHandle() const noexcept;
+    [[nodiscard]] xcb_window_t GetWindowHandle() const noexcept;
 
     /**
      * Initializes the connection to the X server
@@ -57,7 +59,7 @@ private:
     /**
      * Process events from the container window
      */
-    bool ProcessXEvent(const xcb_generic_event_t&) const;
+    [[nodiscard]] bool ProcessXEvent(const xcb_generic_event_t&) const;
 
     enum class EventLoopStatus {
         STOPPED,

--- a/src/platform/linux/ContainerWindow.hpp
+++ b/src/platform/linux/ContainerWindow.hpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#pragma once
+
+#include <xcb/xcb.h>
+
+class ContainerWindow {
+public:
+    class Delegate { };
+
+    explicit ContainerWindow(const Delegate&) noexcept;
+
+    ~ContainerWindow();
+
+    /**
+     * Creates the container window, and initializes the event listeners
+     *
+     * @return True if successful
+     */
+    bool Create(xcb_window_t);
+
+    /**
+     * Return the X window handle of the container window
+     *
+     * @return The X window handle
+     */
+    xcb_window_t GetWindowHandle() const noexcept;
+
+    /**
+     * Initializes the connection to the X server
+     *
+     * @return True if successful
+     */
+    bool MakeXConnection() noexcept;
+
+    void StartEventLoop();
+
+    void StopEventLoop();
+
+private:
+    static xcb_connection_t* Connect(int* screen);
+
+    /**
+     * Find the preferred screen, as identified by `xcb_connect`.
+     *
+     * When calling `xcb_connect` we are passed a preferred screen number. By default this is `0`
+     * but in the case this is something else we will iterate over the available screens
+     * and return back the one which was requested.
+     */
+    static xcb_screen_t* FindPreferredScreen(xcb_connection_t* connection, int preferredScreen);
+
+    /**
+     * Event loop worker
+     */
+    void EventLoop();
+
+    /**
+     * Process events from the container window
+     */
+    bool ProcessXEvent(const xcb_generic_event_t&) const;
+
+    enum class EventLoopStatus {
+        STOPPED,
+        RUNNING,
+    };
+
+    std::unique_ptr<std::thread> m_eventLoopThread;
+
+    const Delegate& m_delegate;
+
+    xcb_connection_t* m_connection;
+    xcb_screen_t* m_screen;
+
+    EventLoopStatus m_status = EventLoopStatus::STOPPED;
+
+    // Container window handle
+    xcb_window_t m_window;
+
+    // Stores the WM_DELETE_WINDOW client message event
+    xcb_intern_atom_reply_t* m_wmDeleteWindowAtom;
+};

--- a/src/platform/linux/JVMSignals.cpp
+++ b/src/platform/linux/JVMSignals.cpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <array>
+#include <csignal>
+
+#include "JVMSignals.hpp"
+
+namespace {
+
+// List of signals which the JVM set, which we want to save and after initializing
+// CEF, restore.
+//
+// https://github.com/chromiumembedded/java-cef/blob/master/native/signal_restore_posix.cpp
+constexpr std::array<int, 13> signalsToRestore = {
+    SIGHUP,
+    SIGINT,
+    SIGQUIT,
+    SIGILL,
+    SIGABRT,
+    SIGFPE,
+    SIGSEGV,
+    SIGALRM,
+    SIGTERM,
+    SIGCHLD,
+    SIGBUS,
+    SIGTRAP,
+    SIGPIPE,
+};
+
+std::array<struct sigaction, signalsToRestore.size()> savedActions;
+
+}
+
+namespace JVMSignals {
+
+void Backup()
+{
+    struct sigaction action { };
+
+    for (size_t i = 0; i < signalsToRestore.size(); ++i) {
+        memset(&action, 0, sizeof(action));
+
+        sigaction(signalsToRestore[i], nullptr, &action);
+
+        savedActions[i] = action;
+    }
+}
+
+void Restore()
+{
+    for (size_t i = 0; i < signalsToRestore.size(); ++i) {
+        sigaction(signalsToRestore[i], &savedActions[i], nullptr);
+    }
+}
+
+}

--- a/src/platform/linux/JVMSignals.hpp
+++ b/src/platform/linux/JVMSignals.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#pragma once
+
+// CefInitialize will overwrite JVM signal handlers. This causes issues with JIT'd code
+// and results in random crashes. Backup the present signal handlers, and after
+// returning from CefInitialize restore them to their previous actions.
+//
+// See: https://bitbucket.org/chromiumembedded/java-cef/issues/41/mac-jcef-frequently-crashing-in-thread
+namespace JVMSignals {
+
+void Backup();
+
+void Restore();
+
+}

--- a/src/platform/linux/LinuxBrowserContext.cpp
+++ b/src/platform/linux/LinuxBrowserContext.cpp
@@ -18,7 +18,7 @@ LinuxBrowserContext::LinuxBrowserContext(std::unique_ptr<LinuxBrowserData> data)
     assert(m_eventLoop != nullptr && "Expected browser event loop to exist!");
 
     m_app = new BrowserApp(*this);
-    m_browserWindow = std::make_unique<BrowserWindow>(*m_data);
+    m_browserWindow = std::make_unique<BrowserWindow>(*m_data, *m_eventLoop);
 }
 
 LinuxBrowserData& LinuxBrowserContext::GetBrowserData() const noexcept { return *m_data; }
@@ -31,9 +31,7 @@ void LinuxBrowserContext::OnContextInitialized() const
         return;
     }
 
-    if (m_browserWindow->Create()) {
-        m_data->SetState(Base::ApplicationState::STARTED);
-    } else {
+    if (!m_browserWindow->Create()) {
         m_data->SetState(Base::ApplicationState::FAILED);
     }
 }

--- a/src/platform/linux/LinuxBrowserContext.cpp
+++ b/src/platform/linux/LinuxBrowserContext.cpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
-#include "src/Browser.hpp"
+#include <iostream>
+
 #include "src/BrowserContext.hpp"
 
 #include "LinuxBrowserContext.hpp"
 
 LinuxBrowserContext::LinuxBrowserContext(std::unique_ptr<LinuxBrowserData> data) noexcept
     : m_data(std::move(data))
+    , m_eventLoop(std::make_unique<BrowserEventLoop>())
 {
     assert(m_data != nullptr && "Expected browser data to exist!");
 }
@@ -20,6 +22,8 @@ bool LinuxBrowserContext::PerformInitialize(JNIEnv* env, jobject canvas)
     if (workingDirectory.empty()) {
         return false;
     }
+
+    m_eventLoop->EnqueueWork(base::BindOnce([] { std::cout << "Hello world\n"; }));
 
     return true;
 }

--- a/src/platform/linux/LinuxBrowserContext.cpp
+++ b/src/platform/linux/LinuxBrowserContext.cpp
@@ -16,6 +16,9 @@ LinuxBrowserContext::LinuxBrowserContext(std::unique_ptr<LinuxBrowserData> data)
     , m_eventLoop(std::make_unique<BrowserEventLoop>())
 {
     assert(m_data != nullptr && "Expected browser data to exist!");
+    assert(m_eventLoop != nullptr && "Expected browser event loop to exist!");
+
+    m_browserWindow = std::make_unique<BrowserWindow>(*m_data, *m_eventLoop);
 }
 
 LinuxBrowserData& LinuxBrowserContext::GetBrowserData() const noexcept { return *m_data; }
@@ -71,6 +74,12 @@ void LinuxBrowserContext::StartCEF() const
     }
 
     JVMSignals::Restore();
+
+    if (!m_browserWindow->CreateHostWindow()) {
+        m_data->SetState(Base::ApplicationState::FAILED);
+
+        return;
+    }
 
     m_data->SetState(Base::ApplicationState::STARTED);
 }

--- a/src/platform/linux/LinuxBrowserContext.hpp
+++ b/src/platform/linux/LinuxBrowserContext.hpp
@@ -11,13 +11,16 @@
 #include "BrowserWindow.hpp"
 #include "LinuxBrowserData.hpp"
 
-class LinuxBrowserContext : public Base::BrowserContext {
+class LinuxBrowserContext : public Base::BrowserContext, private BrowserApp::Delegate {
 public:
     explicit LinuxBrowserContext(std::unique_ptr<LinuxBrowserData>) noexcept;
     ~LinuxBrowserContext() override = default;
 
 private:
     [[nodiscard]] LinuxBrowserData& GetBrowserData() const noexcept override;
+
+    // BrowserApp::Delegate methods
+    void OnContextInitialized() override;
 
     // Platform specific methods
     bool PerformInitialize(JNIEnv*, jobject) override;

--- a/src/platform/linux/LinuxBrowserContext.hpp
+++ b/src/platform/linux/LinuxBrowserContext.hpp
@@ -6,7 +6,9 @@
 
 #include "src/BrowserData.hpp"
 
+#include "BrowserApp.hpp"
 #include "BrowserEventLoop.hpp"
+#include "BrowserWindow.hpp"
 #include "LinuxBrowserData.hpp"
 
 class LinuxBrowserContext : public Base::BrowserContext {
@@ -31,4 +33,5 @@ private:
     CefRefPtr<BrowserApp> m_app;
     std::unique_ptr<LinuxBrowserData> m_data;
     std::unique_ptr<BrowserEventLoop> m_eventLoop;
+    std::unique_ptr<BrowserWindow> m_browserWindow;
 };

--- a/src/platform/linux/LinuxBrowserContext.hpp
+++ b/src/platform/linux/LinuxBrowserContext.hpp
@@ -20,7 +20,7 @@ private:
     [[nodiscard]] LinuxBrowserData& GetBrowserData() const noexcept override;
 
     // BrowserApp::Delegate methods
-    void OnContextInitialized() override;
+    void OnContextInitialized() const override;
 
     // Platform specific methods
     bool PerformInitialize(JNIEnv*, jobject) override;

--- a/src/platform/linux/LinuxBrowserContext.hpp
+++ b/src/platform/linux/LinuxBrowserContext.hpp
@@ -23,6 +23,12 @@ private:
     void PerformResize() override;
     void PerformNavigate() override;
 
+    void StartCEF() const;
+
+    // Store app here since we will exit from PerformInitialize after completion
+    //
+    // Beyond initialization we aren't going to reference it.
+    CefRefPtr<BrowserApp> m_app;
     std::unique_ptr<LinuxBrowserData> m_data;
     std::unique_ptr<BrowserEventLoop> m_eventLoop;
 };

--- a/src/platform/linux/LinuxBrowserContext.hpp
+++ b/src/platform/linux/LinuxBrowserContext.hpp
@@ -6,6 +6,7 @@
 
 #include "src/BrowserData.hpp"
 
+#include "BrowserEventLoop.hpp"
 #include "LinuxBrowserData.hpp"
 
 class LinuxBrowserContext : public Base::BrowserContext {
@@ -13,9 +14,9 @@ public:
     explicit LinuxBrowserContext(std::unique_ptr<LinuxBrowserData>) noexcept;
     ~LinuxBrowserContext() override = default;
 
+private:
     [[nodiscard]] LinuxBrowserData& GetBrowserData() const noexcept override;
 
-private:
     // Platform specific methods
     bool PerformInitialize(JNIEnv*, jobject) override;
     void PerformDestroy() override;
@@ -23,4 +24,5 @@ private:
     void PerformNavigate() override;
 
     std::unique_ptr<LinuxBrowserData> m_data;
+    std::unique_ptr<BrowserEventLoop> m_eventLoop;
 };

--- a/src/platform/linux/LinuxBrowserData.cpp
+++ b/src/platform/linux/LinuxBrowserData.cpp
@@ -13,7 +13,7 @@
  *
  * We require that the browser helper is a sibling of the applet viewer.
  */
-std::filesystem::path LinuxBrowserData::ResolveWorkingDirectory(JNIEnv* env) noexcept
+bool LinuxBrowserData::ResolveWorkingDirectory(JNIEnv* env) noexcept
 {
     jclass system = env->FindClass("java/lang/System");
 
@@ -23,7 +23,7 @@ std::filesystem::path LinuxBrowserData::ResolveWorkingDirectory(JNIEnv* env) noe
             env->ExceptionClear();
         }
 
-        return {};
+        return false;
     }
 
     jmethodID getProperty = env->GetStaticMethodID(system, "getProperty", "(Ljava/lang/String;)Ljava/lang/String;");
@@ -34,7 +34,7 @@ std::filesystem::path LinuxBrowserData::ResolveWorkingDirectory(JNIEnv* env) noe
             env->ExceptionClear();
         }
 
-        return {};
+        return false;
     }
 
     jstring propertyName = env->NewStringUTF("com.open592.workingDirectory");
@@ -45,7 +45,7 @@ std::filesystem::path LinuxBrowserData::ResolveWorkingDirectory(JNIEnv* env) noe
             env->ExceptionClear();
         }
 
-        return {};
+        return false;
     }
 
     // reinterpret_cast is fine here since we know our call to CallStaticObjectMethod will return a jstring
@@ -56,18 +56,18 @@ std::filesystem::path LinuxBrowserData::ResolveWorkingDirectory(JNIEnv* env) noe
             env->ExceptionClear();
         }
 
-        return {};
+        return false;
     }
 
     const char* property = env->GetStringUTFChars(workingDirectory, JNI_FALSE);
 
     if (property == nullptr) {
-        return {};
+        return false;
     }
 
-    std::filesystem::path path = std::filesystem::canonical(property);
+    m_workingDirectory = std::filesystem::canonical(property);
 
     env->ReleaseStringUTFChars(workingDirectory, property);
 
-    return path;
+    return true;
 }

--- a/src/platform/linux/LinuxBrowserData.hpp
+++ b/src/platform/linux/LinuxBrowserData.hpp
@@ -5,13 +5,16 @@
 #include <filesystem>
 
 #include <jni.h>
+#include <xcb/xcb.h>
 
 #include "src/BrowserData.hpp"
 
 class LinuxBrowserData : public Base::BrowserData {
 public:
     [[nodiscard]] std::filesystem::path GetWorkingDirectory() const noexcept { return m_workingDirectory; }
+    [[nodiscard]] xcb_window_t GetHostWindow() const noexcept { return m_hostWindow; }
     [[nodiscard]] bool ResolveWorkingDirectory(JNIEnv*) noexcept;
+    [[nodiscard]] bool ResolveHostWindow(JNIEnv*, jobject) noexcept;
 
 private:
     /**
@@ -20,4 +23,7 @@ private:
      * This path also points to where our helper executable is located.
      */
     std::filesystem::path m_workingDirectory;
+
+    // Host window (Java) handle
+    xcb_window_t m_hostWindow;
 };

--- a/src/platform/linux/LinuxBrowserData.hpp
+++ b/src/platform/linux/LinuxBrowserData.hpp
@@ -11,7 +11,7 @@
 class LinuxBrowserData : public Base::BrowserData {
 public:
     [[nodiscard]] std::filesystem::path GetWorkingDirectory() const noexcept { return m_workingDirectory; }
-    [[nodiscard]] std::filesystem::path ResolveWorkingDirectory(JNIEnv*) noexcept override;
+    [[nodiscard]] bool ResolveWorkingDirectory(JNIEnv*) noexcept;
 
 private:
     /**


### PR DESCRIPTION
This PR adds the base browser view. There is still a number of things left to be implemented:

- Destruction
- Resizing
- Navigation

TODO:
- Currently we are hard-coding the browser rect. There is a bit of work needed here due to the API exposed by the browsercontrol. We will not have the initial size of the browser view until after `browsercontrol()` is called. We should hide the browser until we have a valid size, otherwise CEF will set a size for us.