### PR TITLE
linux: Remove namespace for DesktopBrowserLauncher

### DIFF
--- a/src/platform/linux/BrowserHandler.cpp
+++ b/src/platform/linux/BrowserHandler.cpp
@@ -33,7 +33,7 @@ bool BrowserHandler::OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
     CEF_REQUIRE_UI_THREAD()
 
     // Best effort call
-    DesktopBrowserLauncher::Open(target_url);
+    tryOpenUrlInDesktopBrowser(target_url);
 
     // Block popups
     return true;

--- a/src/platform/linux/DesktopBrowserLauncher.cpp
+++ b/src/platform/linux/DesktopBrowserLauncher.cpp
@@ -95,9 +95,7 @@ const std::optional<std::string> g_desktopBrowserCommand = resolveBrowserCommand
 
 }
 
-namespace DesktopBrowserLauncher {
-
-bool Open(const std::string& URL)
+bool tryOpenUrlInDesktopBrowser(const std::string& URL)
 {
     if (!g_desktopBrowserCommand.has_value()) {
         return false;
@@ -115,6 +113,4 @@ bool Open(const std::string& URL)
     }
 
     return false;
-}
-
 }

--- a/src/platform/linux/DesktopBrowserLauncher.hpp
+++ b/src/platform/linux/DesktopBrowserLauncher.hpp
@@ -4,8 +4,4 @@
 
 #include <string>
 
-namespace DesktopBrowserLauncher {
-
-bool Open(const std::string&);
-
-}
+bool tryOpenUrlInDesktopBrowser(const std::string& URL);


### PR DESCRIPTION
Update the function name to be more descriptive so we don't need a namespace wrapping a single function.