### PR TITLE
build: Fix node 16 deprecation warnings for actions

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
           vsversion: 2022
-      - uses: nuget/setup-nuget@v1
+      - uses: nuget/setup-nuget@v2
       - name: Build browsercontrol library
         run: |
           mkdir .\build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Validate versions
         id: validate-version
         run: |
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ${{ github.workspace }}/artifacts/
       - name: Create release


### PR DESCRIPTION
Fix the following Github action warnings.

![image](https://github.com/Open592/browsercontrol/assets/2308484/c5a9cef2-e7f4-4a67-b7eb-e56b57d0fc8c)

This may also fix an issue where our release action was on download-artifacts v3 while the build actions were on v4
